### PR TITLE
Fullscreen for ios when using 'Add to home screen'

### DIFF
--- a/mopidy_material_webclient/static/index.html
+++ b/mopidy_material_webclient/static/index.html
@@ -6,6 +6,7 @@
     <link href="/material-webclient/css/angular-material.min.css" rel="stylesheet">
     <link href="/material-webclient/css/app.min.css" rel="stylesheet">
     <meta name="viewport" content="initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <title>{{ host }}</title>
 </head>
 <body ng-cloak layout="column">


### PR DESCRIPTION
For ios user in Safari there is a 'Add to home screen' function that creates a app on the home screen which is a shortcut to the url. Without this tag it just opens Safari, with it it creates a coo little full screen app. Thanks!